### PR TITLE
Enable accordion section be active by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex-components/accordion",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Accordion component for react",
   "author": "vitoriaheliane",
   "license": "MIT",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import React, {
   ReactNode,
   useEffect,
   PropsWithChildren,
+  useCallback,
 } from 'react'
 import { Box } from 'theme-ui'
 
@@ -22,37 +23,53 @@ function Accordion({
   mode = 'singleOpen',
   variant = 'vtex-components',
 }: PropsWithChildren<Props>) {
-  const [activeKeys, setActiveKeys] = useState<string[]>([])
+  const [activeKeys, setActiveKeys] = useState<Record<string, boolean>>({})
   const customVariant = `${variant}.accordion`
 
+  const toggleItem = useCallback(
+    (key: string, isActive: boolean) => {
+      setActiveKeys(
+        mode === 'multiOpen'
+          ? (currentKeys) => ({ ...currentKeys, [key]: isActive })
+          : { [key]: isActive }
+      )
+    },
+    [mode]
+  )
+
   useEffect(() => {
-    setActiveKeys([])
+    setActiveKeys({})
   }, [mode])
 
-  const onClickItem = (key: string) => {
-    const index = activeKeys.indexOf(key)
-    const isActive = index > -1
+  useEffect(() => {
+    Children.map(
+      children as ReactElement,
+      (child: ReactElement, index: number) => {
+        const key = index.toString()
 
-    if (isActive) {
-      setActiveKeys((currentKeys) =>
-        currentKeys.filter((current) => current !== key)
-      )
-    } else {
-      setActiveKeys((currentKeys) =>
-        mode === 'multiOpen' ? [...currentKeys, key] : [key]
-      )
-    }
+        if (child.props.isActive) {
+          toggleItem(key, true)
+        }
+      }
+    )
+  }, [children, toggleItem])
+
+  const onClickItem = (key: string, callback?: Function) => {
+    const isActive = activeKeys[key]
+
+    toggleItem(key, !isActive)
+    callback?.(key)
   }
 
   const createSection = (child: ReactElement, index: number) => {
     const id = index.toString()
-    const isActive = activeKeys.indexOf(id) > -1
+    const isActive = activeKeys[id]
 
     const props: CollapsibleProps = {
       ...child.props,
       id,
       isActive,
-      onClick: onClickItem,
+      onClick: () => onClickItem(id, child.props.onClick),
       renderIcon: child.props.renderIcon ?? renderIcon,
       variant: child.props.variant ?? customVariant,
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,7 +27,7 @@ function Accordion({
   const customVariant = `${variant}.accordion`
 
   const toggleItem = useCallback(
-    (key: string, isActive: boolean) => {
+    (key: number, isActive: boolean) => {
       setActiveKeys(
         mode === 'multiOpen'
           ? (currentKeys) => ({ ...currentKeys, [key]: isActive })
@@ -44,9 +44,7 @@ function Accordion({
   useEffect(() => {
     Children.map(
       children as ReactElement,
-      (child: ReactElement, index: number) => {
-        const key = index.toString()
-
+      (child: ReactElement, key: number) => {
         if (child.props.isActive) {
           toggleItem(key, true)
         }
@@ -54,22 +52,21 @@ function Accordion({
     )
   }, [children, toggleItem])
 
-  const onClickItem = (key: string, callback?: Function) => {
+  const onClickItem = (key: number, callback?: Function) => {
     const isActive = activeKeys[key]
 
     toggleItem(key, !isActive)
     callback?.(key)
   }
 
-  const createSection = (child: ReactElement, index: number) => {
-    const id = index.toString()
-    const isActive = activeKeys[id]
+  const createSection = (child: ReactElement, key: number) => {
+    const isActive = activeKeys[key]
 
     const props: CollapsibleProps = {
       ...child.props,
-      id,
+      id: key,
       isActive,
-      onClick: () => onClickItem(id, child.props.onClick),
+      onClick: () => onClickItem(key, child.props.onClick),
       renderIcon: child.props.renderIcon ?? renderIcon,
       variant: child.props.variant ?? customVariant,
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,7 +26,7 @@ function Accordion({
   const [activeKeys, setActiveKeys] = useState<Record<string, boolean>>({})
   const customVariant = `${variant}.accordion`
 
-  const toggleItem = useCallback(
+  const toggleSection = useCallback(
     (key: number, isActive: boolean) => {
       setActiveKeys(
         mode === 'multiOpen'
@@ -46,16 +46,16 @@ function Accordion({
       children as ReactElement,
       (child: ReactElement, key: number) => {
         if (child.props.isActive) {
-          toggleItem(key, true)
+          toggleSection(key, true)
         }
       }
     )
-  }, [children, toggleItem])
+  }, [children, toggleSection])
 
-  const onClickItem = (key: number, callback?: Function) => {
+  const onClickSection = (key: number, callback?: Function) => {
     const isActive = activeKeys[key]
 
-    toggleItem(key, !isActive)
+    toggleSection(key, !isActive)
     callback?.(key)
   }
 
@@ -66,7 +66,7 @@ function Accordion({
       ...child.props,
       id: key,
       isActive,
-      onClick: () => onClickItem(key, child.props.onClick),
+      onClick: () => onClickSection(key, child.props.onClick),
       renderIcon: child.props.renderIcon ?? renderIcon,
       variant: child.props.variant ?? customVariant,
     }
@@ -74,9 +74,9 @@ function Accordion({
     return React.cloneElement(child, props)
   }
 
-  const items = Children.map(children as ReactElement, createSection)
+  const sections = Children.map(children as ReactElement, createSection)
 
-  return <Box variant={customVariant}>{items}</Box>
+  return <Box variant={customVariant}>{sections}</Box>
 }
 
 Accordion.Section = Collapsible

--- a/stories/accordion.stories.tsx
+++ b/stories/accordion.stories.tsx
@@ -17,7 +17,7 @@ const renderIcon = (isActive: boolean) => (
 )
 
 export const SingleOpen = () => {
-  const [mode, setMode] = useState<'singleOpen' | 'multiOpen'>('multiOpen')
+  const [mode, setMode] = useState<'singleOpen' | 'multiOpen'>('singleOpen')
 
   const toggleMode = () => {
     setMode(mode === 'singleOpen' ? 'multiOpen' : 'singleOpen')
@@ -28,7 +28,11 @@ export const SingleOpen = () => {
       <Text>Current mode: {mode}</Text>
       <Button onClick={toggleMode}>Toggle mode</Button>
       <Accordion renderIcon={renderIcon} mode={mode}>
-        <Accordion.Section header="What is Lorem Ipsum?">
+        <Accordion.Section
+          header="What is Lorem Ipsum?"
+          isActive
+          onClick={(id: string) => console.log('clicou no', id)}
+        >
           <Text>
             Lorem Ipsum is simply dummy text of the printing and typesetting
             industry. Lorem Ipsum has been the industrys standard dummy text

--- a/stories/accordion.stories.tsx
+++ b/stories/accordion.stories.tsx
@@ -28,11 +28,7 @@ export const SingleOpen = () => {
       <Text>Current mode: {mode}</Text>
       <Button onClick={toggleMode}>Toggle mode</Button>
       <Accordion renderIcon={renderIcon} mode={mode}>
-        <Accordion.Section
-          header="What is Lorem Ipsum?"
-          isActive
-          onClick={(id: string) => console.log('clicou no', id)}
-        >
+        <Accordion.Section header="What is Lorem Ipsum?" isActive>
           <Text>
             Lorem Ipsum is simply dummy text of the printing and typesetting
             industry. Lorem Ipsum has been the industrys standard dummy text
@@ -45,7 +41,7 @@ export const SingleOpen = () => {
             PageMaker including versions of Lorem Ipsum.
           </Text>
         </Accordion.Section>
-        <Accordion.Section header="How to use it?">
+        <Accordion.Section header="How to use it?" isActive>
           <Text>
             t is a long established fact that a reader will be distracted by the
             readable content of a page when looking at its layout. The point of


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make it possible for the accordion sections to be active by default. If the accordion is in the `singleOpen` mode and more than one of its children must be active by default, only the last one will be active to respect the current accordion mode. 

#### What problem is this solving?
Fix issue #4 

#### How should this be manually tested?
You can test it using the storybook by running the command `yarn storybook`.

#### Screenshots or example usage
In this example, the two sections must be active, when in the `multiOpen` mode the two are active and in the `singleOpen` mode only the second child is active as described previously. 
![right](https://user-images.githubusercontent.com/12852518/90073490-af8fcf80-dccf-11ea-9222-a3fff67a21f1.gif)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)
![](https://media.giphy.com/media/3oKIPbjGTD0zRWStDa/giphy.gif)
