### PR TITLE
Fixes CLS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex-components/accordion",
-  "version": "0.2.1",
+  "version": "0.2.2-beta",
   "description": "Accordion component for react",
   "author": "vitoriaheliane",
   "license": "MIT",

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -1,0 +1,17 @@
+import { ReactElement } from 'react'
+
+export const assertSingleOpen = () => {
+  let isActive = false
+
+  return (child: ReactElement<{ isActive?: boolean }>) => {
+    if (isActive && child.props.isActive) {
+      throw new Error(
+        'Cannot use multiple active Sections in singleOpen mode. Maybe try using multiOpen mode or passing isActive to a single section ?'
+      )
+    }
+
+    if (child.props.isActive) {
+      isActive = true
+    }
+  }
+}

--- a/stories/accordion.stories.tsx
+++ b/stories/accordion.stories.tsx
@@ -41,7 +41,7 @@ export const SingleOpen = () => {
             PageMaker including versions of Lorem Ipsum.
           </Text>
         </Accordion.Section>
-        <Accordion.Section header="How to use it?" isActive>
+        <Accordion.Section header="How to use it?">
           <Text>
             t is a long established fact that a reader will be distracted by the
             readable content of a page when looking at its layout. The point of


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR tries to fix #9 

#### What problem is this solving?
This PR solves the CLS by removing the accordion effect when `isActive` prop is passed to `Section` component.

The main solution was to make the initial state cohesive with the isActive Section props and throws and error when more than one Section isActive in singleOpen mode

#### How should this be manually tested?
Open storybook and check that: 
1. When more than one section is active in singleOpen mode, an error is thrown
2. No visual effect is performed when sections are active on multiOpen mode

#### Screenshots or example usage
<!-- Add screenshots that display the effects of your PR, especially when then involve visible aspects. -->

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? 
![accordion](https://media.giphy.com/media/nKhQFxAzduWpa/giphy.gif)
